### PR TITLE
Add libnotify for notification support.

### DIFF
--- a/net.waterfox.waterfox.yaml
+++ b/net.waterfox.waterfox.yaml
@@ -48,3 +48,15 @@ modules:
         path: net.waterfox.waterfox.desktop
       - type: file
         path: flatpak-prefs.js
+  - name: libnotify
+    buildsystem: meson
+    config-opts:
+      - -Dtests=false
+      - -Dintrospection=disabled
+      - -Dman=false
+      - -Dgtk_doc=false
+      - -Ddocbook_docs=disabled
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/libnotify/0.8/libnotify-0.8.3.tar.xz
+        sha256: ee8f3ef946156ad3406fdf45feedbdcd932dbd211ab4f16f75eba4f36fb2f6c0


### PR DESCRIPTION
Ported directly from [org.mozilla.firefox.BaseApp.json](https://github.com/flathub/org.mozilla.firefox.BaseApp/blob/branch/23.08/org.mozilla.firefox.BaseApp.json)

Verified working with https://www.bennish.net/web-notifications.html

Fixes #28