### PR TITLE
fix(manifest): debug f-e-d-c version-pattern

### DIFF
--- a/net.waterfox.waterfox.yaml
+++ b/net.waterfox.waterfox.yaml
@@ -47,7 +47,7 @@ modules:
         x-checker-data:
           type: html
           url: https://waterfox.net/download
-          version-pattern: ([0-9].[0-9]+[0-9]*.[0-9]+)
+          version-pattern: (\d+\.\d+\.\d+) \(Latest\)
           url-template: https://cdn1.waterfox.net/waterfox/releases/$version/Linux_x86_64/waterfox-$version.tar.bz2
       - type: file
         path: net.waterfox.waterfox.appdata.xml


### PR DESCRIPTION
closes #61

NOTE: the first matching regex group is used for $version

adding "(Latest)" to the pattern is necessary, otherwise flatpak-external-data-checker clobbers the first x.x.x patterns it sees within the HTML (and silently fails at the repository level, as the action is "owned" by the flathub organisation)

relevant docs:

https://docs.flathub.org/docs/for-app-authors/external-data-checker
https://docs.flatpak.org/en/latest/module-sources.html
https://github.com/flathub-infra/flatpak-external-data-checker/wiki/HTML-checker