### PR TITLE
Changed ffmpeg-full version to fix HTML5 players bug

### DIFF
--- a/net.waterfox.waterfox.yaml
+++ b/net.waterfox.waterfox.yaml
@@ -5,7 +5,7 @@ sdk: org.freedesktop.Sdk
 command: waterfox
 add-extensions:
   org.freedesktop.Platform.ffmpeg-full:
-    version: '24.08'
+    version: '23.08'
     directory: lib/ffmpeg
     add-ld-path: .
 cleanup-commands:


### PR DESCRIPTION
This addresses a bug that's present in Firefox upstream since 130 - HTML5 video players either stop playing video or crash after revinding back when hardware acceleration is enabled. Since Waterfox 6.6 is based on Firefox 140, this problem tumbled downstream to Waterfox.

This is most likely caused by the fact, that the highest version of `ffmpeg` Firefox supports is `6.x`, and `ffmpeg-full 24.08` is based on `ffmpeg` branch `7.x` (as seen on Gitlab: https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/releases?before=eyJyZWxlYXNlZF9hdCI6IjIwMjQtMDQtMjcgMjM6MDA6MDAuMDAwMDAwMDAwICswMDAwIiwiaWQiOiIxMTg2ODUwMCJ9).
Manually installing `ffmepg-full 23.08` (which is based on `ffmepg` branch `6.x`) fixes the issue for me in Firefox past 130 (and Waterfox past 6.6).

I described the issue more deeply in Waterfox repository:
https://github.com/BrowserWorks/waterfox/issues/3879