### PR TITLE
Drop ffmpeg extension

### DIFF
--- a/net.waterfox.waterfox.yaml
+++ b/net.waterfox.waterfox.yaml
@@ -3,13 +3,6 @@ runtime: org.freedesktop.Platform
 runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: waterfox
-add-extensions:
-  org.freedesktop.Platform.ffmpeg-full:
-    version: '25.08'
-    directory: lib/ffmpeg
-    add-ld-path: .
-cleanup-commands:
-  - mkdir -p ${FLATPAK_DEST}/lib/ffmpeg
 finish-args:
   - --share=ipc
   - --share=network


### PR DESCRIPTION
Freedesktop runtime version 25.08 (also GNOME runtime 49, KDE runtime 6.10, and 5.15-25.08) provides FFMPEG; therefore, declaring **org.freedesktop.Platform.ffmpeg-full** extension is no longer required.

> in the manifest. org.freedesktop.Platform.codecs-extra will be automatically installed by the runtime and will be available to users.

More information

- https://bbhtt.in/posts/closing-the-chapter-on-openh264/
- https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1825
- https://gitlab.gnome.org/GNOME/gnome-build-meta/-/issues/931
