### PR TITLE
Drop libnotify

### DIFF
--- a/net.waterfox.waterfox.yaml
+++ b/net.waterfox.waterfox.yaml
@@ -65,19 +65,3 @@ modules:
         path: net.waterfox.waterfox.desktop
       - type: file
         path: flatpak-prefs.js
-  - name: libnotify
-    buildsystem: meson
-    config-opts:
-      - -Dtests=false
-      - -Dintrospection=disabled
-      - -Dman=false
-      - -Dgtk_doc=false
-      - -Ddocbook_docs=disabled
-    sources:
-      - type: archive
-        url: https://download.gnome.org/sources/libnotify/0.8/libnotify-0.8.8.tar.xz
-        sha256: 23420ef619dc2cb5aebad613f4823a2fa41c07e5a1d05628d40f6ec4b35bfddd
-        x-checker-data:
-          type: gnome
-          name: libnotify
-          stable-only: true


### PR DESCRIPTION
Already provided by the runtime

Fixes: https://github.com/flathub/net.waterfox.waterfox/issues/114